### PR TITLE
Update to current direction

### DIFF
--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -234,10 +234,10 @@ def compute_current_magnitude_and_direction(level1, level2):
 
     direction = np.degrees(np.arctan2((u_1 + u_2), (v_1 + v_2)))
     ind_pos = direction < 0
-    direction_corrected = np.mod(-xr.where(ind_pos,
+    direction_corrected = np.mod(xr.where(ind_pos,
                                  180 + (180 - np.abs(direction)),
                                  direction
-                                 ) + 90,
+                                 ),
                                  360)
 
     level2['CurrentDirection'] = direction_corrected


### PR DESCRIPTION
Change to current direction computation that corrects issues with wrongly computed current vectors.

With the interferogram sign convention flipped, this change now correctly computes the retrieved current direction on all days of the Iroise Sea campaign, including the 17th (**without any differential treatment of the beam conventions**)

It it now known that the differential treatment of beam direction convention on the 17th effectively compensated for this error in the vector direction computation, thanks to the geophysical structures (current jets) used to visually verify the computed current direction being almost exactly parallel with either the fore or aft beam. Therefore by adjusting a beam direction convention the orthogonal current components were in the right magnitudes for the old version of this function to produce correct current directions.

However on subsequent flights, where a differential beam treatment was not applied, these current directions were incorrect by +90 degrees. This was not fully noticed as the data on the 22nd was, until now, primarily used in the star pattern analysis **which does not make use of this function**

With this change to `compute_current_magnitude_and_direction()`, combined with the phase inversion performed during L1B processing (for **all** beams), current vectors are now correctly computed on all days