### PR TITLE
Issue #264

### DIFF
--- a/seastar/retrieval/ambiguity_removal.py
+++ b/seastar/retrieval/ambiguity_removal.py
@@ -77,7 +77,8 @@ def ambiguity_sort_by_cost(lmout):
     index : ``xarray.DataArray``
         a dataArray index. Can be applied directly to lmout with lmout.isel(Ambiguities=index_cost)
     """
-    index = lmout.cost.argmin(dim='Ambiguities')
+    cost = xr.where(np.isnan(lmout.cost), np.inf, lmout.cost)
+    index = cost.argmin(dim='Ambiguities')
     return index
 
 

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -122,7 +122,7 @@ def sol2level2(sol):
     return level2
 
 
-def run_find_minima(level1, noise, gmf):
+def run_find_minima(level1, noise, gmf, serial=False):
     """
     Run find minima on xD dimension DataSet.
 
@@ -155,9 +155,11 @@ def run_find_minima(level1, noise, gmf):
                 'gmf': gmf,
 
             })
-
-        with multiprocessing.Pool() as pool:
-            lmoutmap = pool.map(find_minima_parallel_task, input_mp)
+        if serial:
+            lmoutmap = map(find_minima_parallel_task, input_mp)
+        else:
+            with multiprocessing.Pool() as pool:
+                lmoutmap = pool.map(find_minima_parallel_task, input_mp)
 
         lmmap = xr.concat(lmoutmap, dim='z')
         lmmap = lmmap.set_index(z=list_L1s0)
@@ -172,8 +174,11 @@ def run_find_minima(level1, noise, gmf):
                 'noise': noise.isel({dim_name: ii}),
                 'gmf': gmf,
             })
-        with multiprocessing.Pool() as pool:
-            lmoutmap = pool.map(find_minima_parallel_task, input_mp)
+        if serial:
+            lmoutmap = map(find_minima_parallel_task, input_mp)
+        else:
+            with multiprocessing.Pool() as pool:
+                lmoutmap = pool.map(find_minima_parallel_task, input_mp)
 
         sol = xr.concat(lmoutmap, dim=dim_name)
         sol = sol.set_index({dim_name: dim_name})


### PR DESCRIPTION
Changes to address Issue #264 causing crashes of find_minima in the case of out-of-bounds x0. 

In test cases with un-physical RSV and Sigma0 this fix does not always flag bad boundary conditions, however it does prevent the function from crashing during parallel computation.