### PR TITLE
Implementation of "OceanSurfaceWind" and "EarthRelativeWind" in place…

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -6,5 +6,5 @@ Version of the codebase
 
 """
 
-__version__ = '2023.06.1'
+__version__ = '2023.06.2'
 

--- a/seastar/gmfs/doppler.py
+++ b/seastar/gmfs/doppler.py
@@ -21,7 +21,7 @@ def compute_total_surface_motion(L1, aux_geo, gmf, **kwargs):
         A Dataset containing IncidenceAngleImage, AntennaAzimuthImage and
         Polarization.
     aux_geo : xarray.Dataset
-        A Dataset containing WindSpeed, WindDirection, CurrentVelocity, CurrentDirection
+        A Dataset containing OceanSurfaceWindSpeed, OceanSurfaceWindDirection, CurrentVelocity, CurrentDirection
     gmf : str
         Option for geophysical model function. 'mouche12', 'yurovsky19'
         with kwargs for options.
@@ -108,7 +108,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
         A Dataset containing IncidenceAngleImage, AntennaAzimuthImage and
         Polarization
     aux_geo : xarray.Dataset
-        A Dataset containing WindSpeed, WindDirection.
+        A Dataset containing OceanSurfaceWindSpeed, OceanSurfaceWindDirection.
     gmf : str
         Option for geophysical model function. 'mouche12', 'yurovsky19'
         with kwargs for options.
@@ -139,9 +139,23 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
     # TODO I really think we might be able just to test L1 and geo are aligned and whatever the dimension
     L1, aux_geo = xr.align(L1, aux_geo, join="outer")
 
+    if 'OceanSurfaceWindSpeed' not in aux_geo.keys():
+        import warnings
+        aux_geo['OceanSurfaceWindSpeed'] = aux_geo['WindSpeed']
+        aux_geo['OceanSurfaceWindDirection'] = aux_geo['WindDirection']
+        warnings.filterwarnings('default',
+                                message='"WindSpeed" and "WindDirection" fields are deprecated. '
+                                        'You should use "OceanSurfaceWindSpeed" and "OceanSurfaceWindDirection" '
+                                        'instead in order to remove this warning.\n'
+                                        '"Wind" are been used here as "OceanSurfaceWind" i.e. '
+                                        'relative to the surface motion',
+                                category=DeprecationWarning,
+                                module=user_ns.get("__name__"))
+
+
     relative_wind_direction =\
         seastar.utils.tools.compute_relative_wind_direction(
-            aux_geo.WindDirection,
+            aux_geo.OceanSurfaceWindDirection,
             L1.AntennaAzimuthImage
         )
 
@@ -153,7 +167,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
     if gmf == 'mouche12':
         if L1.Polarization.size == 1:
             dop_c = mouche12(
-                aux_geo.WindSpeed.values,
+                aux_geo.OceanSurfaceWindSpeed.values,
                 relative_wind_direction.values,
                 L1.IncidenceAngleImage.values,
                 L1.Polarization.data,
@@ -163,7 +177,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
             for pol_str in ('VV', 'HH'):
                 if ind[pol_str].any():
                     dop_c[ind[pol_str]] = mouche12(
-                        aux_geo.WindSpeed.values[ind[pol_str]],
+                        aux_geo.OceanSurfaceWindSpeed.values[ind[pol_str]],
                         relative_wind_direction.values[ind[pol_str]],
                         L1.IncidenceAngleImage.values[ind[pol_str]],
                         pol_str,
@@ -189,7 +203,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
         [dc['VV'], dc['HH']] = yurovsky19(
             L1.IncidenceAngleImage,
             relative_wind_direction,
-            aux_geo.WindSpeed,
+            aux_geo.OceanSurfaceWindSpeed,
             lambdar=central_wavelength,
             **kwargs
         )

--- a/seastar/gmfs/doppler.py
+++ b/seastar/gmfs/doppler.py
@@ -140,17 +140,14 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
     L1, aux_geo = xr.align(L1, aux_geo, join="outer")
 
     if 'OceanSurfaceWindSpeed' not in aux_geo.keys():
-        import warnings
+        import logging
         aux_geo['OceanSurfaceWindSpeed'] = aux_geo['WindSpeed']
         aux_geo['OceanSurfaceWindDirection'] = aux_geo['WindDirection']
-        warnings.filterwarnings('default',
-                                message='"WindSpeed" and "WindDirection" fields are deprecated. '
-                                        'You should use "OceanSurfaceWindSpeed" and "OceanSurfaceWindDirection" '
-                                        'instead in order to remove this warning.\n'
-                                        '"Wind" are been used here as "OceanSurfaceWind" i.e. '
-                                        'relative to the surface motion',
-                                category=DeprecationWarning,)
-
+        logging.warning('"WindSpeed" and "WindDirection" fields are deprecated. '
+                        'You should use "OceanSurfaceWindSpeed" and "OceanSurfaceWindDirection" '
+                        'instead in order to remove this warning.\n'
+                        '"Wind" are been used here as "OceanSurfaceWind" i.e. relative to the surface motion'
+                        )
 
     relative_wind_direction =\
         seastar.utils.tools.compute_relative_wind_direction(

--- a/seastar/gmfs/doppler.py
+++ b/seastar/gmfs/doppler.py
@@ -149,8 +149,7 @@ def compute_wasv(L1, aux_geo, gmf, **kwargs):
                                         'instead in order to remove this warning.\n'
                                         '"Wind" are been used here as "OceanSurfaceWind" i.e. '
                                         'relative to the surface motion',
-                                category=DeprecationWarning,
-                                module=user_ns.get("__name__"))
+                                category=DeprecationWarning,)
 
 
     relative_wind_direction =\

--- a/seastar/gmfs/nrcs.py
+++ b/seastar/gmfs/nrcs.py
@@ -40,8 +40,7 @@ def compute_nrcs(L1_combined, aux_geo, gmf):
                                         'instead in order to remove this warning.\n'
                                         '"Wind" are been used here as "OceanSurfaceWind" i.e. '
                                         'relative to the surface motion',
-                                category=DeprecationWarning,
-                                module=user_ns.get("__name__"))
+                                category=DeprecationWarning,)
 
     nrcs = xr.Dataset()
     for antenna in L1_combined.Antenna.data:

--- a/seastar/gmfs/nrcs.py
+++ b/seastar/gmfs/nrcs.py
@@ -31,16 +31,14 @@ def compute_nrcs(L1_combined, aux_geo, gmf):
 
     # Initialisation / test
     if 'OceanSurfaceWindSpeed' not in aux_geo.keys():
-        import warnings
+        import logging
         aux_geo['OceanSurfaceWindSpeed'] = aux_geo['WindSpeed']
         aux_geo['OceanSurfaceWindDirection'] = aux_geo['WindDirection']
-        warnings.filterwarnings('default',
-                                message='"WindSpeed" and "WindDirection" fields are deprecated. '
-                                        'You should use "OceanSurfaceWindSpeed" and "OceanSurfaceWindDirection" '
-                                        'instead in order to remove this warning.\n'
-                                        '"Wind" are been used here as "OceanSurfaceWind" i.e. '
-                                        'relative to the surface motion',
-                                category=DeprecationWarning,)
+        logging.warning('"WindSpeed" and "WindDirection" fields are deprecated. '
+                        'You should use "OceanSurfaceWindSpeed" and "OceanSurfaceWindDirection" '
+                        'instead in order to remove this warning.\n'
+                        '"Wind" are been used here as "OceanSurfaceWind" i.e. relative to the surface motion'
+                        )
 
     nrcs = xr.Dataset()
     for antenna in L1_combined.Antenna.data:

--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -609,8 +609,8 @@ def init_auxiliary(level1, u10, wind_direction):
                                                     wind_direction,
                                                     level1)
     aux = xr.Dataset()
-    aux['WindSpeed'] = WindSpeed
-    aux['WindDirection'] = WindDirection
+    aux['EarthRelativeWindSpeed'] = WindSpeed
+    aux['EarthRelativeWindDirection'] = WindDirection
 
     return aux
 

--- a/seastar/retrieval/ambiguity_removal.py
+++ b/seastar/retrieval/ambiguity_removal.py
@@ -27,7 +27,7 @@ def ambiguity_closest_to_truth(lmout, truth, windcurrentratio=10):
          coordinates "x_variables" = [u,v,c_u,c_v]; "Ambiguities";
     truth : ``xarray.Dataset``
         Have to contain the following geophysical parameters:
-        WindSpeed, WindDirection, CurrentVelocity, CurrentDirection, others (waves)
+        EarthRelativeWindSpeed, EarthRelativeWindDirection, CurrentVelocity, CurrentDirection, others (waves)
         Should be in the same dimension as lmout
     windcurrentratio : ``float``
         ratio to combine the distance between wind and current. Default value of 10
@@ -39,12 +39,12 @@ def ambiguity_closest_to_truth(lmout, truth, windcurrentratio=10):
     """
 
     mytruth = xr.Dataset()
-    (mytruth['WindU'], mytruth['WindV']) = \
+    (mytruth['EarthRelativeWindU'], mytruth['EarthRelativeWindV']) = \
         seastar.utils.tools.windSpeedDir2UV(truth.WindSpeed, truth.WindDirection)
     (mytruth['CurrentU'], mytruth['CurrentV']) = \
         seastar.utils.tools.currentVelDir2UV(truth.CurrentVelocity, truth.CurrentDirection)
     mytruth['x'] = xr.concat(
-        [mytruth['WindU'], mytruth['WindV'], mytruth['CurrentU'], mytruth['CurrentV']],
+        [mytruth['EarthRelativeWindU'], mytruth['EarthRelativeWindV'], mytruth['CurrentU'], mytruth['CurrentV']],
         'x_variables'
     )
 

--- a/seastar/retrieval/ambiguity_removal.py
+++ b/seastar/retrieval/ambiguity_removal.py
@@ -40,7 +40,7 @@ def ambiguity_closest_to_truth(lmout, truth, windcurrentratio=10):
 
     mytruth = xr.Dataset()
     (mytruth['EarthRelativeWindU'], mytruth['EarthRelativeWindV']) = \
-        seastar.utils.tools.windSpeedDir2UV(truth.WindSpeed, truth.WindDirection)
+        seastar.utils.tools.windSpeedDir2UV(truth.EarthRelativeWindSpeed, truth.EarthRelativeWindDirection)
     (mytruth['CurrentU'], mytruth['CurrentV']) = \
         seastar.utils.tools.currentVelDir2UV(truth.CurrentVelocity, truth.CurrentDirection)
     mytruth['x'] = xr.concat(

--- a/seastar/retrieval/cost_function.py
+++ b/seastar/retrieval/cost_function.py
@@ -56,8 +56,8 @@ def fun_residual(variables, level1, noise, gmf):
 
     geo = xr.Dataset(
         data_vars=dict(
-            WindSpeed=(level1.isel(Antenna=0).IncidenceAngleImage.dims, vis_wspd),
-            WindDirection=(level1.isel(Antenna=0).IncidenceAngleImage.dims, vis_wdir),
+            OceanSurfaceWindSpeed=(level1.isel(Antenna=0).IncidenceAngleImage.dims, vis_wspd),
+            OceanSurfaceWindDirection=(level1.isel(Antenna=0).IncidenceAngleImage.dims, vis_wdir),
             CurrentVelocity=(level1.isel(Antenna=0).IncidenceAngleImage.dims, c_vel),
             CurrentDirection=(level1.isel(Antenna=0).IncidenceAngleImage.dims, c_dir),
         ),

--- a/seastar/retrieval/level2.py
+++ b/seastar/retrieval/level2.py
@@ -43,10 +43,10 @@ def find_minima_parallel_task(element):
 
 def wind_current_retrieval(level1, noise, gmf, ambiguity):
     """
-    Compute ocean surface WIND and CURRENT magnitude and direction
+    Compute ocean surface and earth relative WIND and CURRENT magnitude and direction
     by minimisation of a cost function.
 
-    Compute Ocean Surface Vector Wind (OSVW) in (m/s) and
+    Compute Ocean Surface Vector Wind (OSVW) and Earth Relative (ERW) in (m/s) and
     direction (degrees N) in the meteorological convention (coming from).
     Assumed neutral wind at 10m.
 
@@ -71,9 +71,14 @@ def wind_current_retrieval(level1, noise, gmf, ambiguity):
     level2.CurrentDirection : ``xarray.DataArray``
         Surface current direction (degrees N) in oceanographic convention
         (going to)
-    level2.WindSpeed : ``xarray.DataArray``
+    level2.EarthRelativeWindSpeed : ``xarray.DataArray``
+        EarthRelative Wind Speed (m/s)
+    level2.EarthRelativeWindDirection : ``xarray.DataArray``
+        EarthRelative Wind Direction (degrees N) in meteorologic convention
+        (coming from)
+    level2.OceanSurfaceWindSpeed : ``xarray.DataArray``
         Ocean Surface Wind Speed (m/s)
-    level2.WindDirection : ``xarray.DataArray``
+    level2.OceanSurfaceWindDirection : ``xarray.DataArray``
         Ocean Surface Wind Direction (degrees N) in meteorologic convention
         (coming from)
     """
@@ -87,7 +92,9 @@ def wind_current_retrieval(level1, noise, gmf, ambiguity):
 
 def sol2level2(sol):
     """
-    Convert solution.x into WindU, WindV, WindSpeed, WindCurrent, CurrentU, V, Velocity, Direction
+    Convert solution.x into EarthRelativeWindU, EarthRelativeWindV, EarthRelativeWindSpeed, EarthRelativeWindDirection,
+    same for OceanSurfaceWindU, V, Speed, Direction and
+     CurrentU, V, Velocity, Direction
 
     Parameters
     ----------
@@ -102,22 +109,10 @@ def sol2level2(sol):
     level2['cost'] = sol.cost
     level2['CurrentU'] = level2.x.sel(x_variables='c_u')
     level2['CurrentV'] = level2.x.sel(x_variables='c_v')
-    level2['WindU'] = level2.x.sel(x_variables='u')
-    level2['WindV'] = level2.x.sel(x_variables='v')
+    level2['EarthRelativeWindU'] = level2.x.sel(x_variables='u')
+    level2['EarthRelativeWindV'] = level2.x.sel(x_variables='v')
 
-    [level2['CurrentVelocity'], cdir] = \
-        seastar.utils.tools.currentUV2VelDir(
-            level2['CurrentU'],
-            level2['CurrentV']
-        )
-    level2['CurrentDirection'] = (level2.CurrentVelocity.dims, cdir)
-
-    [level2['WindSpeed'], wdir] = \
-        seastar.utils.tools.windUV2SpeedDir(
-            level2['WindU'],
-            level2['WindV']
-        )
-    level2['WindDirection'] = (level2.WindSpeed.dims, wdir)
+    level2 = seastar.utils.tools.EarthRelativeUV2all(level2)
 
     return level2
 

--- a/seastar/tests/retrieval/test_cost_function.py
+++ b/seastar/tests/retrieval/test_cost_function.py
@@ -34,8 +34,8 @@ def level1_geo_dataset(gmf_mouche):
                           ),
             #             Sigma0=( ['across','along','Antenna'], np.full([5, 6,4], 1.01) ),
             #             dsig0=( ['across','along','Antenna'], np.full([5, 6,4], 0.05) ),
-            #             RVL=( ['across','along','Antenna'], np.full([5, 6,4], 0.5) ),
-            #             drvl=( ['across','along','Antenna'], np.full([5, 6,4], 0.01) ),
+            #             RSV=( ['across','along','Antenna'], np.full([5, 6,4], 0.5) ),
+            #             dRSV=( ['across','along','Antenna'], np.full([5, 6,4], 0.01) ),
         ),
         coords=dict(
             across=np.arange(0, 5),
@@ -69,7 +69,7 @@ def level1_geo_dataset(gmf_mouche):
 
     # TODO warning should be relative wind, not absolute wind
     level1['Sigma0'] = seastar.gmfs.nrcs.compute_nrcs(level1, geo, gmf_mouche.nrcs) * 1.001
-    level1['RVL'] = xr.concat([
+    level1['RSV'] = xr.concat([
         seastar.gmfs.doppler.compute_total_surface_motion(
             level1.sel(Antenna=ant),
             geo,
@@ -77,13 +77,13 @@ def level1_geo_dataset(gmf_mouche):
         ) for ant in level1.Antenna.data],
         'Antenna',
         join='outer')
-    # Add NaN for RVL for the mid antennas
-    level1.RVL[1, :, :] = np.full([5, 6], np.nan)
-    level1.RVL[2, :, :] = np.full([5, 6], np.nan)
+    # Add NaN for RSV for the mid antennas
+    level1.RSV[1, :, :] = np.full([5, 6], np.nan)
+    level1.RSV[2, :, :] = np.full([5, 6], np.nan)
     # Noise
     noise = level1.drop_vars([var for var in level1.data_vars])
     noise['Sigma0'] = level1.Sigma0 * 0.05
-    noise['RVL'] = level1.RVL * 0.05
+    noise['RSV'] = level1.RSV * 0.05
 
     # TODO, we shouldn't do this, it should be fixed value, without calling a function
     return dict({'level1': level1, 'geo': geo, 'noise': noise})
@@ -107,7 +107,7 @@ def test_fun_residual(level1_geo_dataset, gmf_mouche):
         np.array([-3.0, -3.2, -3.2, -3.7,
                   -7.4,  0. ,  0. , -2.4 ]),
         rtol=0.1,
-    )  # cost values for Sigma0, then RVL
+    )  # cost values for Sigma0, then RSV
 
 
 def test_find_minima(level1_geo_dataset, gmf_mouche):

--- a/seastar/tests/retrieval/test_level2.py
+++ b/seastar/tests/retrieval/test_level2.py
@@ -34,8 +34,8 @@ def level1_geo_dataset(gmf_mouche):
                           ),
             #             Sigma0=( ['across','along','Antenna'], np.full([5, 6,4], 1.01) ),
             #             dsig0=( ['across','along','Antenna'], np.full([5, 6,4], 0.05) ),
-            #             RVL=( ['across','along','Antenna'], np.full([5, 6,4], 0.5) ),
-            #             drvl=( ['across','along','Antenna'], np.full([5, 6,4], 0.01) ),
+            #             RSV=( ['across','along','Antenna'], np.full([5, 6,4], 0.5) ),
+            #             dRSV=( ['across','along','Antenna'], np.full([5, 6,4], 0.01) ),
         ),
         coords=dict(
             across=np.arange(0, 5),
@@ -54,8 +54,8 @@ def level1_geo_dataset(gmf_mouche):
 
     geo = xr.Dataset(
         data_vars=dict(
-            WindSpeed=(['across', 'along'], np.full([5, 6], 10)),
-            WindDirection=(['across', 'along'], np.full([5, 6], 150)),
+            EarthRelativeWindSpeed=(['across', 'along'], np.full([5, 6], 10)),
+            EarthRelativeWindDirection=(['across', 'along'], np.full([5, 6], 150)),
             CurrentVelocity=(['across', 'along'], np.full([5, 6], 1)),
             CurrentDirection=(['across', 'along'], np.full([5, 6], 150)),
         ),
@@ -65,21 +65,21 @@ def level1_geo_dataset(gmf_mouche):
         ),
     )
 
+    geo = seastar.utils.tools.EarthRelativeSpeedDir2all(geo)
 
+    # geo['u'], geo['v'] = seastar.utils.tools.windSpeedDir2UV(geo.EarthRelativeWindSpeed, geo.EarthRelativeWindDirection)
+    # [geo['c_u'], geo['c_v']] = seastar.utils.tools.currentVelDir2UV(geo.CurrentVelocity, geo.CurrentDirection)
+    # geo['vis_u'] = geo['u'] - geo['c_u']
+    # geo['vis_v'] = geo['v'] - geo['c_v']
+    # geo['vis_wspd'], vis_wdir = \
+    #     seastar.utils.tools.windUV2SpeedDir(
+    #         geo['vis_u'], geo['vis_v']
+    #     )
+    # geo['vis_wdir'] = (geo.vis_wspd.dims, vis_wdir)
 
-    geo['u'], geo['v'] = seastar.utils.tools.windSpeedDir2UV(geo.WindSpeed, geo.WindDirection)
-    [geo['c_u'], geo['c_v']] = seastar.utils.tools.currentVelDir2UV(geo.CurrentVelocity, geo.CurrentDirection)
-    geo['vis_u'] = geo['u'] - geo['c_u']
-    geo['vis_v'] = geo['v'] - geo['c_v']
-    geo['vis_wspd'], vis_wdir = \
-        seastar.utils.tools.windUV2SpeedDir(
-            geo['vis_u'], geo['vis_v']
-        )
-    geo['vis_wdir'] = (geo.vis_wspd.dims, vis_wdir)
-
-    # TODO geo should use the RelativeWind
+    # TODO geo should use the RelativeWind # TODO solved with EarthRelative...2all
     level1['Sigma0'] = seastar.gmfs.nrcs.compute_nrcs(level1, geo, gmf_mouche.nrcs) * 1.001
-    level1['RVL'] = xr.concat([
+    level1['RSV'] = xr.concat([
         seastar.gmfs.doppler.compute_total_surface_motion(
             level1.sel(Antenna=ant),
             geo,
@@ -87,13 +87,13 @@ def level1_geo_dataset(gmf_mouche):
         ) for ant in level1.Antenna.data],
         'Antenna',
         join='outer')
-    # Add NaN for RVL for the mid antennas
-    level1.RVL[1, :, :] = np.full([5, 6], np.nan)
-    level1.RVL[2, :, :] = np.full([5, 6], np.nan)
+    # Add NaN for RSV for the mid antennas
+    level1.RSV[1, :, :] = np.full([5, 6], np.nan)
+    level1.RSV[2, :, :] = np.full([5, 6], np.nan)
     # Noise
     noise = level1.drop_vars([var for var in level1.data_vars])
     noise['Sigma0'] = level1.Sigma0 * 0.05
-    noise['RVL'] = level1.RVL * 0.05
+    noise['RSV'] = level1.RSV * 0.05
 
     # TODO, we shouldn't do this, it should be fixed value, without calling a function
     return dict({'level1': level1, 'geo': geo, 'noise': noise})
@@ -127,12 +127,12 @@ def test_wind_current_retrieval(level1_geo_dataset, gmf_mouche):
             x=(['x_variables'], [-4.50, 7.80, 0.50, -0.86]),
             CurrentU=([], 0.50),
             CurrentV=([], -0.86),
-            WindU=([], -4.50),
-            WindV=([], 7.80),
+            EarthRelativeWindU=([], -4.50),
+            EarthRelativeWindV=([], 7.80),
             CurrentVelocity=([], 1.00),
             CurrentDirection=([], 150.00),
-            WindSpeed=([], 9.00), # TODO should be 10 if AbsoluteWind, 9 if RelativeWind
-            WindDirection=([], 150.00),
+            EarthRelativeWindSpeed=([], 10.00), # TODO should be 10 if AbsoluteWind, 9 if RelativeWind
+            EarthRelativeWindDirection=([], 150.00),
         ),
     )
 

--- a/seastar/utils/tools.py
+++ b/seastar/utils/tools.py
@@ -181,6 +181,46 @@ def EarthRelativeSpeedDir2all(ds):
 
     return ds
 
+def EarthRelativeUV2all(ds):
+    """
+    Convert a dictionary with Earth Relative wind to Ocean Surface Wind
+
+    Parameters
+    ----------
+    mydict : ``xarray.Dataset``
+        a dictionary with ['EarthRelativeWindU'], ['EarthRelativeWindV'], ['CurrentU'], ['CurrentV'] elements
+    Returns
+    -------
+    mydict : ``xarray.Dataset``
+        a dictionary with previous fields + OceanSurfaceWind elements
+    """
+
+    ds['OceanSurfaceWindU'] = ds['EarthRelativeWindU'] - ds['CurrentU']
+    ds['OceanSurfaceWindV'] = ds['EarthRelativeWindV'] - ds['CurrentV']
+
+    [ds['OceanSurfaceWindSpeed'], oswdir ] = \
+        windUV2SpeedDir(
+            ds['OceanSurfaceWindU'],
+            ds['OceanSurfaceWindV']
+        )
+    ds['OceanSurfaceWindDirection'] = ( ds['OceanSurfaceWindSpeed'].dims, oswdir)
+
+    [ds['EarthRelativeWindSpeed'], erwdir] = \
+        windUV2SpeedDir(
+            ds['EarthRelativeWindU'],
+            ds['EarthRelativeWindV']
+        )
+    ds['EarthRelativeWindDirection'] = ( ds['EarthRelativeWindSpeed'].dims, erwdir)
+
+    [ds['CurrentVelocity'], cdir] = \
+        currentUV2VelDir(
+            ds['CurrentU'],
+            ds['CurrentV']
+        )
+    ds['CurrentDirection'] = ( ds['CurrentVelocity'].dims, cdir)
+
+    return ds
+
 def windCurrentUV2all(mydict):
     """
     Convert a dictionary with ['u'], ['v'], ['c_u'], ['c_v'] elements to


### PR DESCRIPTION
Implementation of "OceanSurfaceWind" and "EarthRelativeWind" in place of the ambiguous "Wind". All references to "WindSpeed" and "WindDirection" should have been removed.

It remains reference to Wind in oscar/level1/init_auxiliary. Do we still use this function?

@DavidMcCann-NOC and/or @elemerle could you please run the processing chain for one track for both the iterative and simultaneous retrieval using this branch before we merge it to the main.

@d-andrievskaia it runs on my SciRec branch, I will push it to the main and ask you to review.