### PR TITLE
add VScode settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 .idea/vcs.xml
 .idea/workspace.xml
 .idea
+
+# VS Code
+seastar/.vscode/settings.json


### PR DESCRIPTION
VScode creates a settings.json file every time settings are changed on a new branch. This is IDE-specific and doesn't need to be included in the repository - adding it to .gitignore avoids accidental commits