### PR TITLE
Mid corr intensity

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -6,5 +6,5 @@ Version of the codebase
 
 """
 
-__version__ = '2023.10.3'
+__version__ = '2025.01.1'
 

--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -275,7 +275,7 @@ def compute_multilooking_Master_Slave(ds, window=3,
     if len(ds.SigmaImageSingleLookRealPart.dims) > 2:
         raise Exception("The variable SigmaImageSingleLookRealPart is not a"
                         "2D variable. Please check this variable's dimensions")
-    ds_out = ds.copy()
+    ds_out = xr.Dataset()
     if 'SigmaSLCMaster' not in ds.data_vars:
         ds = compute_SLC_Master_Slave(ds)
 


### PR DESCRIPTION
I changed the version in _version.py and one line in level1.py after discussion with Adrien.

I also run the test with pytest with this branch and had one failed:
FAILED seastar_project/seastar/tests/retrieval/test_level2.py::test_wind_current_retrieval - AssertionError: Left and right Dataset objects are not close
