### PR TITLE
update of the environnement

### DIFF
--- a/env/environment.yml
+++ b/env/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - python
   - matplotlib
   - netcdf4
-  - notebook
   - numpy
   - scipy
   - packaging

--- a/env/environment.yml
+++ b/env/environment.yml
@@ -3,17 +3,17 @@ channels:
 #  - defaults
   - conda-forge
 dependencies:
-  - matplotlib=3.5.1
-  - netcdf4=1.5.7
-  - notebook=6.4.11
-  - numpy=1.22.4
-  - scipy=1.7.3
+  - python
+  - matplotlib
+  - netcdf4
+  - notebook
+  - numpy
+  - scipy
   - packaging
   - pip
-  - python=3.8
-  - sphinx=4.4.0
-  - sphinx_rtd_theme=1.0.0
-  - xarray=2022.11.0
-  - cartopy=0.18.0
-  - utm=0.7.0
+  - sphinx
+  - sphinx_rtd_theme
+  - xarray
+  - cartopy
+  - utm
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,20 +6,19 @@ version = '1.0'
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">= 3.8"                     # Python required version
-matplotlib = "3.5.1"                      # Matplotlib
-netcdf4 = "1.5.7"                         # NetCDF4
-notebook = "6.4.11"                       # Notebook
-numpy = "1.22.4"                          # NumPy
-scipy = "1.7.3"                           # SciPy
+python = "*"                              # Python
+matplotlib = "*"                          # Matplotlib
+netcdf4 = "*"                             # NetCDF4
+numpy = "*"                               # NumPy
+scipy = "*"                               # SciPy
 packaging = "*"                           # Packaging
 pip = "*"                                 # Pip
-sphinx = "4.4.0"                          # Sphinx
-sphinx_rtd_theme = "1.0.0"                # Sphinx RTD Theme
-xarray = "2022.11.0"                      # Xarray
-utm = "0.7.0"                             # UTM
+sphinx = "*"                              # Sphinx
+sphinx_rtd_theme = "*"                    # Sphinx RTD Theme
+xarray = "*"                              # Xarray
+utm = "*"                                 # UTM
 pytest = "*"                              # Test librairy
-dask = "2023.5.0"                         # Dask
+dask = "*"                                # Dask
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/seastar/oscar/level1.py
+++ b/seastar/oscar/level1.py
@@ -41,7 +41,7 @@ def fill_missing_variables(ds_dict, antenna_id):
         for antenna_2 in [a for a in antenna_list if a not in [antenna_1]]:
             for var in ds_dict[antenna_1].data_vars:
                 if var not in ds_dict[antenna_2].data_vars:
-                    ds_dict[antenna_2][var] = xr.DataArray(data=np.NaN)
+                    ds_dict[antenna_2][var] = xr.DataArray(data=np.nan)
 
     return ds_dict
 
@@ -306,15 +306,15 @@ def compute_multilooking_Master_Slave(ds, window=3,
                                        * ds_out.IntensityAvgSlave)
 
     else:
-        ds_out['IntensityAvgSlave'] = xr.DataArray(data=np.NaN)
+        ds_out['IntensityAvgSlave'] = xr.DataArray(data=np.nan)
 
-        ds_out['IntensityAvgComplexMasterSlave'] = xr.DataArray(data=np.NaN)
+        ds_out['IntensityAvgComplexMasterSlave'] = xr.DataArray(data=np.nan)
 
         ds_out['Intensity'] = ds_out.IntensityAvgMaster 
 
-        ds_out['Interferogram'] = xr.DataArray(data=np.NaN)
+        ds_out['Interferogram'] = xr.DataArray(data=np.nan)
 
-        ds_out['Coherence'] = xr.DataArray(data=np.NaN)
+        ds_out['Coherence'] = xr.DataArray(data=np.nan)
 
     ds_out.IntensityAvgMaster.attrs['long_name'] = \
         'Intensity Master'
@@ -474,7 +474,7 @@ def compute_time_lag_Master_Slave(ds, options):
                 'Time difference between antenna master and slave.'
             TimeLag.attrs['units'] = 's'
         else:
-            TimeLag = xr.DataArray(data=np.NaN)
+            TimeLag = xr.DataArray(data=np.nan)
             TimeLag.attrs['long_name'] = 'Time lag'
             TimeLag.attrs['description'] =\
                 'Time difference between antenna master and slave.'\
@@ -617,7 +617,7 @@ def init_auxiliary(level1, u10, wind_direction):
     return aux
 
 
-def replace_dummy_values(ds, dummy_val=-9999, replace=np.NaN):
+def replace_dummy_values(ds, dummy_val=-9999, replace=np.nan):
     """
     Replace dummy values.
 


### PR DESCRIPTION
Link to the issue #309 

The current environnement is in python 3.8 which start to be outdated. So I created 2 environnements:
	- One with the yml and the toml which don't specify the versions
	In this env the tests pass modifying the np.NaN to np.nan in oscar/level1.py
	Cmd pip install -e works 
      - One with the yml file as it is in git in which the versions are specified: seastar_py38
	With this env the tests pass with the correction of np.NaN to np.nan in oscar/level1.py

To test the new environnement to process L1b data: the L1b processing has been made for three tracks (calibration track, tracks  1 and 2) from DEC2024 MetaSensing data and went well. 
Differences in Intensity_dB and Interferogram are of the order of 1e-15 and of 1e-16 for Coherence